### PR TITLE
Add linux-image-extra in depends of linux-image-estuary

### DIFF
--- a/deb/kernel/ubuntu-meta-package/debian/control.d/generic
+++ b/deb/kernel/ubuntu-meta-package/debian/control.d/generic
@@ -11,7 +11,7 @@ Package: linux-image@SUFFIX@
 Architecture: i386 amd64 armhf arm64 ppc64el s390x
 Section: kernel
 Priority: optional
-Depends: ${misc:Depends}, linux-image-${kernel-abi-version}-generic, linux-image-extra-${kernel-abi-version}-generic [i386 amd64 ppc64el s390x], linux-firmware
+Depends: ${misc:Depends}, linux-image-${kernel-abi-version}-generic, linux-image-extra-${kernel-abi-version}-generic [i386 amd64 ppc64el s390x arm64], linux-firmware
 Recommends: thermald [i386 amd64]
 Description: Generic Linux kernel image
  This package will always depend on the latest generic kernel image


### PR DESCRIPTION
Many drivers like nic, sas etc are in linux-image-extra package.
So we need to install linux-image-extra when installing kernel packages.

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>