### PR TITLE
Remove backport preference pip configuration

### DIFF
--- a/deb/kernel/debian-di/pre-pkgsel.d/60-erp
+++ b/deb/kernel/debian-di/pre-pkgsel.d/60-erp
@@ -1,19 +1,12 @@
 #! /bin/sh
 set -e
 
-cat > /target/etc/apt/preferences.d/linaro.pref << EOF
-Package: *
-Pin: release n=jessie-backports
-Pin-Priority: 500
-EOF
-
 cat > /target/etc/apt/sources.list.d/erp-17.08.list <<EOF
 ## ERP 17.08 Stable Overlay
 deb http://repo.linaro.org/debian/erp-17.08-stable jessie main
 deb-src http://repo.linaro.org/debian/erp-17.08-stable jessie main
 deb http://repo.linaro.org/debian/erp-17.08-staging jessie main
 deb-src http://repo.linaro.org/debian/erp-17.08-staging jessie main
-
 EOF
 
 cp /usr/share/linaro/linarorepo.key /target/tmp/key.pub

--- a/deb/kernel/debian-di/pre-pkgsel.d/61-estuary-netboot
+++ b/deb/kernel/debian-di/pre-pkgsel.d/61-estuary-netboot
@@ -2,10 +2,6 @@
 set -e
 
 cat > /target/etc/apt/preferences.d/estuary.pref << EOF
-Package: *
-Pin: release n=jessie-backports
-Pin-Priority: 500
-
 # estuary ftp repo
 Package: *
 Pin: origin "117.78.41.188"
@@ -21,10 +17,6 @@ cat > /target/etc/apt/sources.list.d/estuary.list <<EOF
 ## Estuary 5.0 Overlay
 deb ftp://repoftp:repopushez7411@117.78.41.188/releases/5.0/debian/ estuary-5.0 main
 deb-src ftp://repoftp:repopushez7411@117.78.41.188/releases/5.0/debian/ estuary-5.0 main
-
-# jessie-backports, previously on backports.debian.org
-deb http://deb.debian.org/debian/ jessie-backports main
-deb-src http://deb.debian.org/debian/ jessie-backports main
 EOF
 
 cp /usr/share/estuary/estuaryrepo.key /target/tmp/key.pub

--- a/deb/kernel/debian-di/pre-pkgsel.d/62-estuary-cdrom
+++ b/deb/kernel/debian-di/pre-pkgsel.d/62-estuary-cdrom
@@ -2,10 +2,6 @@
 set -e
 
 cat > /target/etc/apt/preferences.d/estuary.pref << EOF
-Package: *
-Pin: release n=jessie-backports
-Pin-Priority: 500
-
 # estuary ftp repo
 Package: *
 Pin: origin "117.78.41.188"


### PR DESCRIPTION
Make backport as normal pip priority aka 500 will
cause package installation dependency issue.
such as:
python-reportbug : Depends: python-debianbts (>= 1.13)
 but it is not going to be installed

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>